### PR TITLE
Support options for JWT.decode

### DIFF
--- a/lib/rack/jwt/auth/auth_token.rb
+++ b/lib/rack/jwt/auth/auth_token.rb
@@ -4,13 +4,14 @@ module Rack
 
       module AuthToken
 
+        # Note: this method is only used by specs
         def self.issue_token(payload, secret)
           JWT.encode(payload, secret)
         end
 
-        def self.valid?(token, secret)
+        def self.valid?(token, secret, opts = {})
           begin
-            JWT.decode(token, secret)
+            JWT.decode(token, secret, true, opts)
           rescue
             false
           end

--- a/rack-jwt-auth.gemspec
+++ b/rack-jwt-auth.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jwt", "~> 1.0"
+  spec.add_dependency "jwt", ">= 1.5.2"
 
   spec.add_development_dependency "bundler",   "~> 1.3"
   spec.add_development_dependency "rake",      "~> 10.3"

--- a/spec/auth_token_spec.rb
+++ b/spec/auth_token_spec.rb
@@ -28,11 +28,16 @@ describe Rack::Jwt::Auth::AuthToken do
       expect(data['username']).to eql(data[:username])
     end
 
+    it 'supports options to verify the token' do
+      token = JWT.encode(data, secret, 'HS256')
+      payload = subject.valid?(token, secret, { algorithm: 'RS256' })
+
+      expect(payload).not_to be
+    end
+
     it 'checks if the provided token is invalid when decoded with other secret' do
       token   = subject.issue_token(data, secret)
       payload = subject.valid?(token, 'secret')
-
-      meta, data = payload
 
       expect(payload).not_to be
     end

--- a/spec/authenticate_options_spec.rb
+++ b/spec/authenticate_options_spec.rb
@@ -116,5 +116,22 @@ describe Rack::Jwt::Auth::Authenticate do
 
   end
 
+  context "with options for decode" do
+    let(:secret) { 'supertestsecret' }
+    let(:app) do
+      main_app = lambda { |env| [200, env, ['Hello']] }
+      described_class.new(main_app, { secret: secret, algorithm: 'RS256' })
+    end
+
+    it 'calls AuthToken.valid? with decode options' do
+      allow(Rack::Jwt::Auth::AuthToken).to receive(:valid?).and_call_original
+      token = JWT.encode({user_id: 1, username: 'test'}, secret, 'HS256')
+      get('/', {}, {'HTTP_AUTHORIZATION' => "Bearer #{token}"})
+
+      expect(Rack::Jwt::Auth::AuthToken).to have_received(:valid?)
+          .with(token, secret, { algorithm: 'RS256' })
+    end
+  end
+
 
 end


### PR DESCRIPTION
This change allows additional options for `JWT.decode` to be specified when configuring the middleware.

If specified, then the options that apply are passed to `JWT.decode` via `AuthToken.valid?`.

`jwt` v1.5.2 is required to support some of these options, and the ability to verify the specified algorithm is the main motivation for this change.

CC @jturkel 